### PR TITLE
quick fix for issue #303

### DIFF
--- a/src/harmony.ts
+++ b/src/harmony.ts
@@ -521,13 +521,15 @@ export class HarmonyAdapter extends Adapter {
             });
         }
 
+        let actIdx = 0;
         for (const activity of config.activity) {
             const activityLabel = fixId(activity.label).replace('.', '_');
             this.hubs[hub].activities[activity.id] = activityLabel;
             this.hubs[hub].activitiesReverse[activityLabel] = activity.id;
-            if (activity.id === '-1') {
+            if (actIdx >= config.activity.length) {
                 return;
             }
+            actIdx++
             // create activities
             const activityChannelName = `${channelName}.${activityLabel}`;
             // create channel for activity


### PR DESCRIPTION
The exit condition for the loop to create the activities was activity.id '-1' (PowerOff). This activity doesn't necessarily come as the last one. Maybe there's a better way like sorting the activities descending before processing them, but this workaround does it's job so far.